### PR TITLE
Potential fix for code scanning alert no. 85: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/01.build.yml
+++ b/.github/workflows/01.build.yml
@@ -1,5 +1,8 @@
 name: 01.build
 
+permissions:
+  contents: read
+
 on: 
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/MoneyYu/SimpleWeb/security/code-scanning/85](https://github.com/MoneyYu/SimpleWeb/security/code-scanning/85)

To fix the problem, explicitly declare `permissions` for the workflow or job so that the automatically provided `GITHUB_TOKEN` is restricted to the minimum required capabilities. This workflow only checks out code and runs .NET restore/build/test; it does not push, create releases, or modify issues/PRs. Therefore, it only needs read access to repository contents.

The best fix without changing functionality is to add a `permissions` block with `contents: read`. This can be done at the workflow root (applying to all jobs) or inside the `build` job. Since there is only one job, either is fine; using the root-level block is slightly clearer as a default for future jobs. Concretely, in `.github/workflows/01.build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` keys (lines 1–3). No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
